### PR TITLE
Changed coffee link to reflect the link used on the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ While this extension is completely free and ad-free, you can support its develop
 - ⭐ Starring this repository
 - 🐛 Reporting bugs and suggesting features
 - 💻 Contributing code improvements
-- ☕ [Buying us a coffee](https://www.buymeacoffee.com/maple)
+- ☕ [Buying us a coffee](https://www.buymeacoffee.com/shamith)
 
 ## Contributing
 


### PR DESCRIPTION
Noticed that the link used in the readme was different from the links on https://savewithmaple.vercel.app/. Am I correct that I should donate to the updated link?

PS: it looks like some private key is also available in the repo. Maybe that should be deleted too